### PR TITLE
Precache video and audio

### DIFF
--- a/src/routes/quiz.js
+++ b/src/routes/quiz.js
@@ -10,7 +10,7 @@ export default function Quiz() {
   const [quiz, setQuiz] = useState(null)
   let params = useParams()
 
-  let infoURL = `api/quizzes/${params.quizId}?populate=*`
+  let infoURL = `api/quizzes/${params.quizId}?populate=%2A`
   useEffect(() => {
     fetchQuizInfo()
       .then(data => {


### PR DESCRIPTION
Video and audio are served in byte ranges, therefore they cannot be cached with a fetch. It must be explicitly precached with add.